### PR TITLE
Add updates endpoint to V2 case reports controller

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,16 +42,16 @@ jobs:
           cat variables.txt
 
       - name: Upload Variables Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: variables
           path: variables.txt
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Variables Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: variables
           path: ./
@@ -68,7 +68,7 @@ jobs:
           docker save --output image.docker $IMAGE_NAME:$IMAGE_TAG
 
       - name: Cache Docker Layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -76,19 +76,19 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Cache Bundle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock', '**/*.gemspec') }}
 
       - name: Upload Docker Image Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image
           path: image.docker
 
       - name: Set up Docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Download Docker Image Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-image
           path: ./
@@ -138,7 +138,7 @@ jobs:
         run: docker load --input ./image.docker
 
       - name: Download Variables Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: variables
           path: ./

--- a/app/controllers/api/v2/case_reports_controller.rb
+++ b/app/controllers/api/v2/case_reports_controller.rb
@@ -4,8 +4,8 @@ class Api::V2::CaseReportsController < ApplicationController
   include FiltrationConcern
 
   before_action :perform_authorization, only: [:index, :updates]
-  before_action :set_audit_additional_data, only: [:create, :show, :update]
-  before_action :set_case_reports, only: [:show, :update, :index]
+  before_action :set_audit_additional_data, only: [:create, :show, :update, :updates]
+  before_action :set_case_reports, only: [:show, :update, :index, :updates]
   before_action :set_case_report, only: [:show, :update]
 
   def index
@@ -55,10 +55,9 @@ class Api::V2::CaseReportsController < ApplicationController
     limit = (params[:limit] || 100).to_i
     limit = 100 if limit <= 0 || limit > 1000
 
-    # Query for updated case reports
-    case_reports_query = CaseReport.where("created_at >= ?", 10.days.ago)
+    # Query for updated case reports using the @case_reports from the filter
+    case_reports_query = @case_reports.where("created_at >= ?", 10.days.ago)
                                    .where('updated_at > ?', updated_after + 0.000001.seconds)
-                                   .filter_records(auth_params.to_h)
 
     # Order by updated_at and limit results
     case_reports = case_reports_query.order(updated_at: :asc)

--- a/app/controllers/api/v2/case_reports_controller.rb
+++ b/app/controllers/api/v2/case_reports_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::CaseReportsController < ApplicationController
   include PaginationConcern
   include FiltrationConcern
 
-  before_action :perform_authorization, only: [:index]
+  before_action :perform_authorization, only: [:index, :updates]
   before_action :set_audit_additional_data, only: [:create, :show, :update]
   before_action :set_case_reports, only: [:show, :update, :index]
   before_action :set_case_report, only: [:show, :update]
@@ -28,6 +28,62 @@ class Api::V2::CaseReportsController < ApplicationController
 
   def show
     render json: V2::CaseReportSerializer.render(@case_report, root: :case_report)
+  end
+
+  # Supports Aselo integration API
+  def updates
+    # Ensure required parameters are present
+    unless params[:updated_after].present?
+      render json: { error: 'Missing required parameter: updated_after' }, status: :bad_request
+      return
+    end
+
+    begin
+      # Parse the updated_after timestamp
+      updated_after = Time.zone.parse(params[:updated_after])
+      # Additional validation to ensure we have a valid Time object
+      if updated_after.nil?
+        render json: { error: 'Invalid timestamp format for updated_after' }, status: :bad_request
+        return
+      end
+    rescue ArgumentError, TypeError
+      render json: { error: 'Invalid timestamp format' }, status: :bad_request
+      return
+    end
+
+    # Get the limit parameter (default to 100)
+    limit = (params[:limit] || 100).to_i
+    limit = 100 if limit <= 0 || limit > 1000
+
+    # Query for updated case reports
+    case_reports_query = CaseReport.where("created_at >= ?", 10.days.ago)
+                                   .where('updated_at > ?', updated_after + 0.000001.seconds)
+                                   .filter_records(auth_params.to_h)
+
+    # Order by updated_at and limit results
+    case_reports = case_reports_query.order(updated_at: :asc)
+                                     .limit(limit + 1) # Get one extra to determine if there are more
+
+    # Check if there are more results
+    has_more = case_reports.size > limit
+    case_reports = case_reports.first(limit) if has_more
+
+    # Get the next timestamp if there are more results
+    next_timestamp = has_more && case_reports.last ? case_reports.last.updated_at.iso8601 : nil
+
+    # Serialize the case reports
+    response = {
+      status: 'success',
+      case_reports: V2::CaseReportSerializer.render_as_hash(
+        case_reports,
+        view: :list_view
+      )
+    }
+
+    # Add next_timestamp if there are more results
+    response[:next_timestamp] = next_timestamp if next_timestamp
+
+    render json: response, status: :ok
   end
 
   private

--- a/app/serializers/v2/case_report_serializer.rb
+++ b/app/serializers/v2/case_report_serializer.rb
@@ -2,7 +2,7 @@ class V2::CaseReportSerializer < ApplicationSerializer
   identifier :id
   fields :datacenter_id, :datacenter_name, :incident_number, :incident_id, :incident_at, :incident_number,
          :revisions_count, :report_type, :user_id, :responder_name, :patient_name, :patient_dob, :incident_address,
-         :content, :name, :attachments, :created_at
+         :content, :name, :attachments, :created_at, :updated_at
 
   field :direct_upload_urls, if: ->(_field_name, _user, options) { options[:with_direct_upload_urls] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resources :case_reports, only: [:create, :show, :update, :index] do
+        collection do
+          get :updates
+        end
         resources :revisions, only: [:index, :show]
         resources :audits, only: [:index]
       end


### PR DESCRIPTION
This commit adds a new endpoint to retrieve case reports updated after a specified timestamp:
- Implements new /api/v2/case_reports/updates route
- Adds precision buffer to avoid duplicates with exact timestamp matches
- Updates serializer to include updated_at field in response

This endpoint supports Aselo integration by providing a way to efficiently sync case reports data between systems.