### PR TITLE
BD-1438-fix-case-report-deletion-logic-not-to-clog-the-server

### DIFF
--- a/app/jobs/delete_case_reports_job.rb
+++ b/app/jobs/delete_case_reports_job.rb
@@ -1,0 +1,11 @@
+class DeleteCaseReportsJob < ApplicationJob
+  queue_as :default
+
+  def perform(datacenter_id, user)
+
+    CaseReport.where(datacenter_id: datacenter_id, deleted: nil).find_each(batch_size: 1) do |report|
+      WipeSensitiveData.new(user).wipe_one(report)
+      sleep(0.1)
+    end
+  end
+end

--- a/app/services/wipe_sensitive_data.rb
+++ b/app/services/wipe_sensitive_data.rb
@@ -11,12 +11,6 @@
     r
   end
 
-  def wipe_many(scope)
-    r = Result.new(total: scope.count, attachments_deleted: 0, audits_cleared: 0, errors: [])
-    scope.find_each { |report| wipe!(report, r) }
-    r
-  end
-
   private
 
   def wipe!(report, result)


### PR DESCRIPTION
Several things that I've done to minimize server overload while batch deleting case reports from the datacenter:

1) created a background job that runs asynchronously and does not interfere with other processes
2) added `batching` (so that loading and deleting is performed one by one and not as a whole batch of records at a time) along with 1ms `sleep` time between performing the job which also smoothes the workload, throttles the job and prevents database hammering
3) added additional parameter for finding Case Reports for deletion 

`CaseReport.where(datacenter_id: datacenter_id, deleted: nil).exists?`

before it was only checking for datacenter_id and since we were only doing `soft deletion` so for example for 10 000 records in total there could be 7 000 already deleted but without `deleted: nil` check it would delete all 10 000 over and over again.

With all these time needed to perform the action and CPU load have both decreased (sample batch was 139 case reports)

 <img width="563" height="50" alt="Screenshot 2026-01-10 at 12 55 09 PM" src="https://github.com/user-attachments/assets/959f0f62-550a-4f0a-a255-e715d8d53ca9" />

vs 

<img width="552" height="53" alt="Screenshot 2026-01-10 at 12 47 22 PM" src="https://github.com/user-attachments/assets/6e87e9a9-a13e-4e9f-9394-ed04f6be53b8" />