### PR TITLE
BD-2297 - Added cipher and logic to create public ids

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,7 @@
 DATABASE_USER=db
 DATABASE_PASSWORD=secret
+
+# Region/server abbreviation embedded in generated public_ids (e.g. "C-PAR-2026-000123")
+SERVER_ABBREVIATION=DEV
+# Secret key for the public_id cipher; must be at least 32 characters
+PUBLIC_ID_CIPHER_KEY=change-me-change-me-change-me-1234

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -163,6 +163,7 @@ jobs:
           AWS_BUCKET=beacon-uploads-staging
           AWS_REGION=us-east-1
           S3_ENDPOINT=http://minio:9001
+          PUBLIC_ID_CIPHER_KEY=ci-test-public-id-cipher-key-0123456789
           IMAGE_NAME=$IMAGE_NAME
           IMAGE_TAG=$IMAGE_TAG
           t=1

--- a/app/helpers/six_digit_cipher_helper.rb
+++ b/app/helpers/six_digit_cipher_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SixDigitCipherHelper
+  module_function
+
+  RADIX = 1000 # each half is 0..999
+  DOMAIN = RADIX * RADIX # exactly 1,000,000 — no dead zone
+  ROUNDS = 4
+
+  def scramble(n)
+    left  = n / RADIX
+    right = n % RADIX
+    ROUNDS.times { |i| left, right = right, (left + f(right, i)) % RADIX }
+    left * RADIX + right
+  end
+
+  def f(right, round)
+    d = OpenSSL::HMAC.digest("SHA256", key, "#{round}:#{right}")
+    d.unpack1("N") % RADIX
+  end
+
+  def key
+    ENV.fetch("PUBLIC_ID_CIPHER_KEY") # raises KeyError at use if unset
+  end
+end

--- a/app/models/case_report.rb
+++ b/app/models/case_report.rb
@@ -13,6 +13,7 @@ class CaseReport < ApplicationRecord
   has_many :report_audits, foreign_key: :auditable_id
 
   before_create :set_defaults
+  before_create :assign_public_id, if: -> { public_id.blank? }
 
   validates_presence_of :datacenter_id, :incident_number, :incident_id
 
@@ -44,6 +45,7 @@ class CaseReport < ApplicationRecord
     super || audit&.created_at
   end
 
+  def public_id_prefix = "C"
 
   def pdf_attachments
     self.only_pdf_attachments
@@ -92,4 +94,18 @@ class CaseReport < ApplicationRecord
     self.content          ||= {}
   end
 
+  def assign_public_id
+    year   = Time.current.year
+    number = SixDigitCipherHelper.scramble(next_public_id_number(public_id_prefix, year))
+    server_abbreviation = Rails.application.config.x.server_abbreviation
+    self.public_id =
+      "#{public_id_prefix}-#{server_abbreviation}-#{year}-#{format('%06d', number)}"
+  end
+
+  def next_public_id_number(prefix, year)
+    seq  = "public_id_#{prefix.downcase}_#{year}"
+    conn = self.class.connection
+    conn.execute("CREATE SEQUENCE IF NOT EXISTS #{conn.quote_table_name(seq)}")
+    conn.select_value("SELECT nextval(#{conn.quote(seq)})").to_i
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,9 @@ module CaseReportMs
 
     # Add additional load paths for your own custom dirs
     config.autoload_paths += %W(#{config.root}/lib)
+
+    # Region/server abbreviation embedded in generated public_ids
+    # (e.g. "C-<abbr>-<year>-<number>"). Region deployments supply it via ENV.
+    config.x.server_abbreviation = ENV["SERVER_ABBREVIATION"]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.x.server_abbreviation = "DEV"
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/environments/paris.rb
+++ b/config/environments/paris.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  config.x.server_abbreviation = "EU3"
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  config.x.server_abbreviation = "VA2"
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  config.x.server_abbreviation = "STG"
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Deterministic abbreviation so public_id specs can assert an exact format.
+  config.x.server_abbreviation = "TST"
+
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  config.x.server_abbreviation = "UAT"
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/initializers/public_id_cipher.rb
+++ b/config/initializers/public_id_cipher.rb
@@ -1,0 +1,3 @@
+if ENV["PUBLIC_ID_CIPHER_KEY"].to_s.length < 32
+  raise "PUBLIC_ID_CIPHER_KEY must be set and at least 32 characters"
+end

--- a/db/migrate/20260619000025_add_public_id_to_case_reports.rb
+++ b/db/migrate/20260619000025_add_public_id_to_case_reports.rb
@@ -1,0 +1,6 @@
+class AddPublicIdToCaseReports < ActiveRecord::Migration[7.0]
+  def change
+    add_column :case_reports, :public_id, :string
+    add_index :case_reports, :public_id, unique: true
+  end
+end

--- a/db/migrate/20260619000025_add_public_id_to_case_reports.rb
+++ b/db/migrate/20260619000025_add_public_id_to_case_reports.rb
@@ -1,6 +1,5 @@
 class AddPublicIdToCaseReports < ActiveRecord::Migration[7.0]
   def change
     add_column :case_reports, :public_id, :string
-    add_index :case_reports, :public_id, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_30_190544) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_19_000025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,6 +87,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_30_190544) do
     t.integer "case_report_user_id"
     t.boolean "deleted"
     t.string "case_report_user_email"
+    t.string "public_id"
+    t.index ["public_id"], name: "index_case_reports_on_public_id", unique: true
   end
 
   create_table "report_attachments", force: :cascade do |t|

--- a/spec/helpers/six_digit_cipher_helper_spec.rb
+++ b/spec/helpers/six_digit_cipher_helper_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SixDigitCipherHelper do
+  let(:key) { 'a' * 32 }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('PUBLIC_ID_CIPHER_KEY').and_return(key)
+  end
+
+  describe '.scramble' do
+    it 'is deterministic for a given key' do
+      expect(described_class.scramble(123_456)).to eq(described_class.scramble(123_456))
+    end
+
+    it 'always returns a value within the 0..999_999 domain' do
+      [0, 1, 999_999, 500_000, rand(0..999_999)].each do |n|
+        expect(described_class.scramble(n)).to be_between(0, 999_999)
+      end
+    end
+
+    it 'is a bijection (distinct inputs map to distinct outputs)' do
+      inputs  = (0...5000).to_a
+      outputs = inputs.map { |n| described_class.scramble(n) }
+      expect(outputs.uniq.size).to eq(inputs.size)
+    end
+
+    it 'produces a different mapping under a different key' do
+      original = described_class.scramble(123_456)
+
+      allow(ENV).to receive(:fetch).with('PUBLIC_ID_CIPHER_KEY').and_return('b' * 32)
+      expect(described_class.scramble(123_456)).not_to eq(original)
+    end
+
+    it 'raises when the cipher key is not set' do
+      allow(ENV).to receive(:fetch).with('PUBLIC_ID_CIPHER_KEY').and_raise(KeyError)
+      expect { described_class.scramble(123_456) }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/models/case_report_spec.rb
+++ b/spec/models/case_report_spec.rb
@@ -80,4 +80,25 @@ RSpec.describe CaseReport, type: :model do
       end
     end
   end
+
+  describe 'public_id' do
+    it 'has a "C" prefix' do
+      expect(CaseReport.new.public_id_prefix).to eq('C')
+    end
+
+    it 'assigns a public_id on create matching the expected format' do
+      expect(case_report.public_id).to match(/\AC-TST-#{Time.current.year}-\d{6}\z/)
+    end
+
+    it 'does not override a public_id supplied at create time' do
+      report = FactoryBot.create(:case_report, public_id: 'C-TST-2000-000001')
+      expect(report.public_id).to eq('C-TST-2000-000001')
+    end
+
+    it 'assigns distinct public_ids to consecutive case reports' do
+      first  = FactoryBot.create(:case_report)
+      second = FactoryBot.create(:case_report)
+      expect(first.public_id).not_to eq(second.public_id)
+    end
+  end
 end


### PR DESCRIPTION
[BD-2297]

See https://github.com/black-iris-org/beacon/pull/1002 for backend companion PR

This PR prepares the framework for creating somewhat obfuscated public IDs. The main part is the cipher that reversibly obfuscates incident IDs inserted in order. it combines them with the year, server abbreviation and incident type to create the public ID. Migrations and supporting logic are provided as well

[BD-2297]: https://trek-medics.atlassian.net/browse/BD-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ