### PR TITLE
BD-2283 - Added public ID to serializers + tests

### DIFF
--- a/app/serializers/v1/case_report_serializer.rb
+++ b/app/serializers/v1/case_report_serializer.rb
@@ -1,6 +1,6 @@
 class V1::CaseReportSerializer < ApplicationSerializer
   identifier :id
-  fields :incident_number, :incident_id, :incident_at,
+  fields :public_id, :incident_number, :incident_id, :incident_at,
          :report_type, :attachments, :case_report_user_id, :case_report_user_email
 
   # Other Views

--- a/app/serializers/v2/case_report_serializer.rb
+++ b/app/serializers/v2/case_report_serializer.rb
@@ -1,6 +1,6 @@
 class V2::CaseReportSerializer < ApplicationSerializer
   identifier :id
-  fields :datacenter_id, :datacenter_name, :incident_number, :incident_id, :incident_at, :incident_number,
+  fields :public_id, :datacenter_id, :datacenter_name, :incident_number, :incident_id, :incident_at, :incident_number,
          :revisions_count, :report_type, :user_id, :responder_name, :patient_name, :patient_dob, :incident_address,
          :content, :name, :attachments, :created_at, :updated_at
 

--- a/spec/controllers/api/v1/case_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/case_reports_controller_spec.rb
@@ -49,3 +49,49 @@ RSpec.describe "GET /show auditing", type: :request do
     expect(show_audit.last_name).to eq("Last Name 1")
   end
 end
+
+RSpec.describe Api::V1::CaseReportsController, type: :request do
+  include JsonResponse
+
+  let!(:case_report) { FactoryBot.create(:case_report) }
+
+  let(:valid_attributes) { { incident_number: 1, incident_id: 1, incident_at: Time.now,
+                             report_type: :amended, responder_name: 'test', name: 'test' } }
+
+  let(:headers) do
+    {
+      'Requester-Id':              '1',
+      'Requester-Role':            'Admin',
+      'Requester-Name':            Faker::Name.name,
+      'Requester-Email':           Faker::Internet.email,
+      'Requester-First-Name':      Faker::Name.first_name,
+      'Requester-Last-Name':       Faker::Name.last_name,
+      'Requester-Datacenter':      '1',
+      'Requester-Datacenter-Name': 'test'
+    }
+  end
+
+  describe 'GET #show' do
+    it 'returns public_id' do
+      get "/api/v1/case_reports/#{case_report.id}", headers: headers
+
+      expect(json_response[:case_report]).to include(public_id: case_report.public_id)
+    end
+  end
+
+  describe 'GET #index' do
+    it 'returns public_id' do
+      get "/api/v1/case_reports", headers: headers
+
+      expect(json_response[:case_reports].first).to include(public_id: case_report.public_id)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'returns public_id' do
+      post "/api/v1/case_reports", params: { case_report: valid_attributes }, headers: headers
+
+      expect(json_response[:case_report]).to have_key('public_id')
+    end
+  end
+end

--- a/spec/controllers/api/v2/case_reports_controller_spec.rb
+++ b/spec/controllers/api/v2/case_reports_controller_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
 
       it 'should create case_report' do
         expect(CaseReport.count).to eq(1)
+        expect(json_response[:case_report]).to have_key('public_id')
         expect(json_response[:case_report].with_indifferent_access).to include(datacenter_id:    1,
                                                                                datacenter_name:  'test',
                                                                                incident_id:      valid_attributes[:incident_id],
@@ -131,7 +132,8 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
 
       it 'should update case_report' do
         expect(json_response[:case_report].symbolize_keys)
-          .to include(datacenter_id:   1,
+          .to include(public_id:       case_report_1.public_id,
+                      datacenter_id:   1,
                       datacenter_name: 'test',
                       incident_id:     case_report_1.incident_id,
                       incident_number: case_report_1.incident_number,
@@ -254,7 +256,8 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
         case_report_1.reload
 
         expect(json_response[:case_report])
-          .to include(datacenter_id:    1,
+          .to include(public_id:        case_report_1.public_id,
+                      datacenter_id:    1,
                       datacenter_name:  'test',
                       incident_id:      case_report_1.incident_id,
                       incident_number:  case_report_1.incident_number,
@@ -310,6 +313,7 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
       it 'case_report_2' do
         expect(json_response[:case_reports].first.with_indifferent_access)
           .to include(id:               case_report_2.id,
+                      public_id:        case_report_2.public_id,
                       datacenter_id:    1,
                       datacenter_name:  'test',
                       incident_id:      case_report_2.incident_id,
@@ -326,6 +330,7 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
         get "/api/v2/case_reports", headers: headers
         expect(json_response[:case_reports].last.with_indifferent_access)
           .to include(id:               case_report_1.id,
+                      public_id:        case_report_1.public_id,
                       datacenter_id:    1,
                       datacenter_name:  'test',
                       incident_id:      case_report_1.incident_id,
@@ -352,6 +357,7 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
       it 'case_report_2' do
         expect(json_response[:case_reports].first.with_indifferent_access)
           .to include(id:               case_report_2.id,
+                      public_id:        case_report_2.public_id,
                       datacenter_id:    1,
                       datacenter_name:  'test',
                       incident_id:      case_report_2.incident_id,
@@ -367,6 +373,7 @@ RSpec.describe Api::V2::CaseReportsController, type: :request do
       it 'case_report_1' do
         expect(json_response[:case_reports].last.with_indifferent_access)
           .to include(id:               case_report_1.id,
+                      public_id:        case_report_1.public_id,
                       datacenter_id:    1,
                       datacenter_name:  'test',
                       incident_id:      case_report_1.incident_id,

--- a/spec/factories/case_reports.rb
+++ b/spec/factories/case_reports.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
       }
     end
 
-    sequence(:public_id) { |n| "C-TEST-2026-#{n}" }
     incident_number { rand(1..2147483647) }
     incident_id { 1 }
     datacenter_id { 1 }

--- a/spec/factories/case_reports.rb
+++ b/spec/factories/case_reports.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
       }
     end
 
+    sequence(:public_id) { |n| "C-TEST-2026-#{n}" }
     incident_number { rand(1..2147483647) }
     incident_id { 1 }
     datacenter_id { 1 }


### PR DESCRIPTION
[BD-2283]

This PR adds public ID to endpoints + relevant tests

[BD-2283]: https://trek-medics.atlassian.net/browse/BD-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ